### PR TITLE
Fix early returns in select

### DIFF
--- a/src/main/scala/bornfs.scala
+++ b/src/main/scala/bornfs.scala
@@ -626,7 +626,7 @@ case class Dataset(raw_data: Seq[(ArrayBuffer[(Attr, Value)], Value)], sort: Int
           println("<< Tutorial finishes.  Thank you!")
         }
 
-        prefix.toSeq
+        return prefix.toSeq
       } else {
         addPrefix(i)
 
@@ -654,10 +654,9 @@ case class Dataset(raw_data: Seq[(ArrayBuffer[(Attr, Value)], Value)], sort: Int
             println("<< Tutorial finishes.  Thank you!")
           }
 
-          prefix.map(entity(_)).toSeq
+          return prefix.map(entity(_)).toSeq
         }
       }
     }
-    Seq[Attr]()
   }
 }


### PR DESCRIPTION
## Summary
- stop looping once select finds no valid index
- stop looping once search range exhausted
- remove unreachable code

## Testing
- `sbt test` *(fails: sbt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684438c03044832caa05112c2ae3653a