### PR TITLE
Fix Case comparison and add tests

### DIFF
--- a/src/main/scala/bornfs.scala
+++ b/src/main/scala/bornfs.scala
@@ -112,11 +112,14 @@ case class Case(var row: ArrayBuffer[(Attr,Value)], val classLabel: Value, val f
       val x = this.window(i)
       val y = that.window(i)
       if(x._1 <= index) {
-        x._1 - y._1 match {
-          case diff if diff < 0 => return 1
-          case diff if diff > 0 => return -1
-          case _ => i += 1
-        }
+        if(y._1 > index) return 1
+        val diffIndex = x._1 - y._1
+        if(diffIndex < 0) return -1
+        if(diffIndex > 0) return 1
+        val diffValue = x._2 - y._2
+        if(diffValue < 0) return -1
+        if(diffValue > 0) return 1
+        i += 1
       } else {
         return if(y._1 <= index) -1 else 0
       }

--- a/src/test/scala/CaseCompareSpec.scala
+++ b/src/test/scala/CaseCompareSpec.scala
@@ -1,0 +1,21 @@
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import scala.collection.mutable.ArrayBuffer
+
+class CaseCompareSpec extends AnyFunSuite with Matchers {
+  test("compare uses value ordering when indices match") {
+    val c1 = Case(ArrayBuffer((0,1),(1,1)), 0, 1)
+    val c2 = Case(ArrayBuffer((0,1),(1,2)), 0, 1)
+    c1.compare(c2,1) should be < 0
+    c2.compare(c1,1) should be > 0
+  }
+
+  test("lexicographical ordering considers both index and value") {
+    val c1 = Case(ArrayBuffer((0,1),(1,2)), 0, 1)
+    val c2 = Case(ArrayBuffer((0,2),(1,1)), 0, 1)
+    val c3 = Case(ArrayBuffer((0,2),(1,2)), 0, 1)
+    val arr = Array(c3, c2, c1)
+    val sorted = arr.sortWith((x,y) => x.compare(y,1) < 0)
+    sorted.toSeq shouldEqual Seq(c1, c2, c3)
+  }
+}


### PR DESCRIPTION
## Summary
- compare case values when feature indices are equal
- add tests for ordering of cases with multi-valued features

## Testing
- `sbt test` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68443dcff458832ca0b392a764f10065