### PR TITLE
Fix hop help text

### DIFF
--- a/src/main/scala/Reader.scala
+++ b/src/main/scala/Reader.scala
@@ -105,7 +105,7 @@ object Main {
 
       opt[Int]('h', "hop").valueName("<value>").action { (x, o) =>
         o.copy(hop = x)
-      } text("Threshold: 1.0 (default)")
+      } text("Hop interval: 1 (default)")
 
       opt[String]('l', "log").valueName("<high,low,none>").action { (x, o) =>
         o.copy(log = x)


### PR DESCRIPTION
## Summary
- clarify help text for `hop` option

## Testing
- `sbt test` *(fails: sbt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68443fc9a57c832ca208e0bceb11c8e3