### PR TITLE
Migrate project to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,20 @@
-// scalaVersion := "2.11.6"
-scalaVersion := "2.12.9"
+scalaVersion := "3.3.1"
 
-scalacOptions ++= Seq("-unchecked","-deprecation","-feature")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 libraryDependencies += "nz.ac.waikato.cms.weka" % "weka-dev" % "3.7.12"
 
-// libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.4"
+libraryDependencies += "com.github.scopt" %% "scopt" % "4.1.0"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
 
-//  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1",
-//  "org.scala-lang.modules" %% "scala-swing" % "1.0.1",
-
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.0"
 resolvers += Resolver.sonatypeRepo("public")
 javacOptions ++= Seq("-source", "11", "-target", "11")
 
 assemblyMergeStrategy in assembly := {
- case PathList("META-INF", _*) => MergeStrategy.discard
- case _                        => MergeStrategy.first
+  case PathList("META-INF", _*) => MergeStrategy.discard
+  case _                        => MergeStrategy.first
 }
-// test
+
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.19"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.9.8

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin{"com.eed3si9n" % "sbt-assembly" % "0.14.10"}
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/src/test/scala/bornfsSpec.scala
+++ b/src/test/scala/bornfsSpec.scala
@@ -2,6 +2,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
 
 class DataSetupTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
   
@@ -17,8 +18,10 @@ class DataSetupTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     var verbose: Boolean = true
     var hop: Int= 1
     var threshold: Double = 1.0
-    val mapdata: ArrayBuffer[Tuple2[ArrayBuffer[Tuple2[Int, Int]], Int]] = data.sparse_instances.to[ArrayBuffer].map{x =>
-      (x._1.map{y => (data.attr2index(y._1), y._2)}, x._2)}
+    val mapdata: Seq[(ArrayBuffer[(Int, Int)], Int)] =
+      data.sparse_instances.to(mutable.ArrayBuffer).map { x =>
+        (x._1.map(y => (data.attr2index(y._1), y._2)), x._2)
+      }.toSeq
     println(mapdata)
     val ds: Dataset = Dataset(mapdata, sort, tutorial, verbose)
     println("=== ready test data ===")


### PR DESCRIPTION
## Summary
- update sbt build for Scala 3
- update project plugins and sbt version
- replace deprecated JavaConversions and procedure syntax
- add scala-parallel-collections and CollectionConverters
- fix tests for new collection APIs

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_684468e765d0832cb7a33689ff11c62e