### PR TITLE
Fix compare logic and add regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Ensure you have the following installed before running the project:
 - Java `JDK 11`
 - [SBT](https://www.scala-sbt.org/) (Scala Build Tool)
 
+## Data Requirements
+
+BornFS assumes that feature values are discrete. In particular, best results are
+obtained when each feature takes binary values (0 or 1).
+
 ## Installation
 
 ### Clone the Repository

--- a/data/multi.arff
+++ b/data/multi.arff
@@ -1,0 +1,14 @@
+@relation multi
+
+@attribute a {0,1,2}
+@attribute b {0,1,2}
+@attribute c {0,1,2}
+@attribute class {0,1}
+
+@data
+0,0,0,0
+1,0,1,0
+2,1,1,1
+2,2,2,1
+1,1,0,0
+0,2,1,1

--- a/src/main/scala/bornfs.scala
+++ b/src/main/scala/bornfs.scala
@@ -116,7 +116,12 @@ case class Case(var row: ArrayBuffer[(Attr,Value)], val classLabel: Value, val f
         x._1 - y._1 match {
           case diff if diff < 0 => return 1
           case diff if diff > 0 => return -1
-          case _ => i += 1
+          case _ =>
+            x._2 - y._2 match {
+              case diff if diff < 0 => return 1
+              case diff if diff > 0 => return -1
+              case _ => i += 1
+            }
         }
       } else {
         return if(y._1 <= index) -1 else 0
@@ -552,7 +557,7 @@ case class Dataset(raw_data: Seq[(ArrayBuffer[(Attr, Value)], Value)], sort: Int
 
       var sorted, order = (0 to lim).toArray
 
-      if(hop > 0 & it_count % hop == 0) {
+      if(hop > 0 && it_count % hop == 0) {
         val tempResult = sortAttrs
         sorted = tempResult._1
         order = tempResult._2

--- a/src/test/scala/CaseCompareSpec.scala
+++ b/src/test/scala/CaseCompareSpec.scala
@@ -1,0 +1,11 @@
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ArrayBuffer
+
+class CaseCompareSpec extends AnyFunSuite {
+  test("Case.compare uses feature values when indexes match") {
+    val c1 = Case(ArrayBuffer((0,1), (2,1)), 0, 1)
+    val c2 = Case(ArrayBuffer((0,1), (2,2)), 0, 1)
+    assert(c1.compare(c2, 2) == 1)
+    assert(c2.compare(c1, 2) == -1)
+  }
+}

--- a/src/test/scala/HopZeroSpec.scala
+++ b/src/test/scala/HopZeroSpec.scala
@@ -1,0 +1,17 @@
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
+
+class HopZeroSpec extends AnyFunSuite {
+  test("select works when hop is zero") {
+    val path = "data/test.arff"
+    val data = ARFFReader(path)
+    val mapdata: Seq[(ArrayBuffer[(Int, Int)], Int)] =
+      data.sparse_instances.to(mutable.ArrayBuffer).map { x =>
+        (x._1.map(y => (data.attr2index(y._1), y._2)), x._2)
+      }.toSeq
+    val ds = Dataset(mapdata, sort = 0, tutorial = false, verbose = false)
+    val result = ds.select(1.0, hop = 0)
+    assert(result.isInstanceOf[Seq[Int]])
+  }
+}

--- a/src/test/scala/MultiDatasetSpec.scala
+++ b/src/test/scala/MultiDatasetSpec.scala
@@ -1,0 +1,17 @@
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
+
+class MultiDatasetSpec extends AnyFunSuite {
+  test("BornFS handles multi-valued features") {
+    val path = "data/multi.arff"
+    val data = ARFFReader(path)
+    val mapdata: Seq[(ArrayBuffer[(Int, Int)], Int)] =
+      data.sparse_instances.to(mutable.ArrayBuffer).map { x =>
+        (x._1.map(y => (data.attr2index(y._1), y._2)), x._2)
+      }.toSeq
+    val ds = Dataset(mapdata, sort = 0, tutorial = false, verbose = false)
+    val result = ds.select(1.0, hop = 1)
+    assert(result.nonEmpty)
+  }
+}


### PR DESCRIPTION
## Summary
- fix feature comparison to account for values
- avoid divide by zero in `select` by using logical and
- document discrete/binary feature requirement
- provide a small multi-valued example dataset
- add tests for comparison, hop=0, and multi-valued data

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_6844e08184cc832c921beca761f13bc9