### PR TITLE
Fix division by zero when mutual information is zero

### DIFF
--- a/src/main/scala/Reader.scala
+++ b/src/main/scala/Reader.scala
@@ -337,8 +337,10 @@ object Main {
       val mis = ds.entropyPrefix + hc - ds.entropyPrefixLabel
       log_file.write("## I(Selected; C) = " + f.format(mis) + "\n")
       log_file.write("## H(Selected | C) = " + f.format(ds.entropyPrefix - mis) + "\n")
-      val muh = 2*mis/(ds.miEntireLabel + ds.entropyPrefix)
-      val mug = mis/math.sqrt(ds.miEntireLabel * ds.entropyPrefix)
+      val denomH = ds.miEntireLabel + ds.entropyPrefix
+      val denomG = ds.miEntireLabel * ds.entropyPrefix
+      val muh = if(denomH == 0.0) 0.0 else 2*mis/denomH
+      val mug = if(denomG == 0.0) 0.0 else mis/math.sqrt(denomG)
       log_file.write("## mu_H = " + f.format(muh) + "\n")
       log_file.write("## mu_G = " + f.format(mug) + "\n")
 

--- a/src/main/scala/bornfs.scala
+++ b/src/main/scala/bornfs.scala
@@ -371,7 +371,7 @@ case class Dataset(raw_data: Seq[(ArrayBuffer[(Attr, Value)], Value)], sort: Int
 
     val (h, hc) = entropyPrefixPlusUntil(i)
 
-    (entropyLabel + h - hc)/miEntireLabel
+    if(isZero(miEntireLabel)) 0.0 else (entropyLabel + h - hc)/miEntireLabel
   }
 
   def findBorder(delta: Double, lim: Index): Int = {
@@ -645,8 +645,12 @@ case class Dataset(raw_data: Seq[(ArrayBuffer[(Attr, Value)], Value)], sort: Int
           println("* Relevance I(Selected;Class) = " + f.format(relevance) + ";")
           println("* Noise H(Selected|Class) = " + f.format(noise) + ".")
           println("The harmonic and geometric means of I(S;C)/I(E;C) and I(S;C)/H(FS) are computed as:")
-          println("* mu_H = " + f.format(2 * relevance/(miEntireLabel + entropyPrefix)) + ";")
-          println("* mu_G = " + f.format(relevance/math.sqrt(miEntireLabel * entropyPrefix)) + ".")
+          val denomH = miEntireLabel + entropyPrefix
+          val denomG = miEntireLabel * entropyPrefix
+          val mu_H = if(isZero(denomH)) 0.0 else 2 * relevance/denomH
+          val mu_G = if(isZero(denomG)) 0.0 else relevance/math.sqrt(denomG)
+          println("* mu_H = " + f.format(mu_H) + ";")
+          println("* mu_G = " + f.format(mu_G) + ".")
         } else if(verbose) {
           print("." + entity(i) + ".")
         }

--- a/src/test/scala/ZeroMutualInfoSpec.scala
+++ b/src/test/scala/ZeroMutualInfoSpec.scala
@@ -1,0 +1,22 @@
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable.ArrayBuffer
+
+class ZeroMutualInfoSpec extends AnyFunSuite {
+  test("BornFS handles zero mutual information without division by zero") {
+    val data = Seq(
+      (ArrayBuffer((0,1), (1,1)), 0),
+      (ArrayBuffer((0,1), (1,1)), 1)
+    )
+    val ds = Dataset(data, sort = 0, tutorial = false, verbose = false)
+    assert(ds.ratio(-1) == 0.0)
+    val selected = ds.select(1.0, hop = 1)
+    val relevance = ds.entropyPrefix + ds.entropyLabel - ds.entropyPrefixLabel
+    val denomH = ds.miEntireLabel + ds.entropyPrefix
+    val denomG = ds.miEntireLabel * ds.entropyPrefix
+    val muH = if(denomH == 0.0) 0.0 else 2 * relevance / denomH
+    val muG = if(denomG == 0.0) 0.0 else relevance / math.sqrt(denomG)
+    assert(muH == 0.0)
+    assert(muG == 0.0)
+    assert(selected.isInstanceOf[Seq[Int]])
+  }
+}


### PR DESCRIPTION
## Summary
- avoid dividing by zero in `ratio`
- handle zero denominators when computing `mu_H` and `mu_G`
- apply same safeguard when logging run statistics
- add a regression test for datasets with zero mutual information

## Testing
- `./sbt test`

------
https://chatgpt.com/codex/tasks/task_e_6844ffad24fc832c86039ada304bb3bc