### PR TITLE
Fix newline at end of Scala test

### DIFF
--- a/src/test/scala/bornfsSpec.scala
+++ b/src/test/scala/bornfsSpec.scala
@@ -38,3 +38,4 @@ class DataSetupTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     selected_attrs shouldBe expected_attrs
   }
 }
+


### PR DESCRIPTION
## Summary
- ensure newline at EOF in bornfsSpec.scala

## Testing
- `sbt test` *(fails: sbt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ffb36b18832cb6264644143f5307