### PR TITLE
Fix incorrect window sort in BornFS

### DIFF
--- a/src/main/scala/bornfs.scala
+++ b/src/main/scala/bornfs.scala
@@ -97,7 +97,9 @@ case class Case(var row: ArrayBuffer[(Attr,Value)], val classLabel: Value, val f
       temp.append((order(p._1), p._2))
       i += 1
     }
-    window = temp.sortWith(_._1 < _._1)
+    // Ensure the window is sorted by the new index order
+    // so that subsequent binary searches behave correctly.
+    window = temp.sortBy(_._1)
   }
 
   def compare(that: Case, index: Index): Int = {


### PR DESCRIPTION
## Summary
- sort case window entries by index when renumbering

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_684534bda530832c8aab92718065ecca