### PR TITLE
Disable tests during assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,3 +18,6 @@ assemblyMergeStrategy in assembly := {
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.19"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
 
+// Disable running tests when building the fat JAR
+test in assembly := {}
+


### PR DESCRIPTION
## Summary
- prevent ScalaTest from running when creating assembly JAR

## Testing
- `apt-get update` *(fails: command not found for sbt)*

------
https://chatgpt.com/codex/tasks/task_e_68453c4b228c832c94213639689888b3